### PR TITLE
Change import section from Copyable to tsCopyable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ class Person{
 
 
 ```ts
-import Copyable  from 'ts-copyable';
+import tsCopyable from 'ts-copyable';
 ```
 
 ```ts
-class Person extends Copyable<Person>{
+class Person extends tsCopyable<Person>{
     constructor(readonly name: string, readonly age: number){
         super(Person);
     }


### PR DESCRIPTION
I use this library using Visual Studio Code.
At that time,It said to `Copyable` with `tsCopyable`.

Therefore I create this patch.

<img width="501" alt="2019-01-16 16 57 57" src="https://user-images.githubusercontent.com/1155067/51234381-e7c61380-19af-11e9-8419-76cb62c761a7.png">
